### PR TITLE
Update build.yml (install missing requirements)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,10 @@ jobs:
           ~/.TinyTeX/bin/x86_64-linux/tlmgr option sys_bin ~/.local/bin
           ~/.TinyTeX/bin/x86_64-linux/tlmgr path add
           ~/.TinyTeX/bin/x86_64-linux/tlmgr install libertinus-fonts
+      
+      - name: Install additional system requirements
+        run: |
+          apt-get -y install libmagick++-6.q16-dev
   
       - name: Install Computo extension for Quarto
         run: |


### PR DESCRIPTION
Add new configuration step to install missing requirements in github actions run.

Missing `libMagick++-6.Q16.so.8`, c.f. https://github.com/JuJacques/MultivariateCountData/actions/runs/11219023703/job/31184054931