### PR TITLE
Add TinyTeX path for diagram generation in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,25 +2,21 @@ name: Main Workflows
 
 on:
   push:
-    branches:
-      - main
+    branches: ["main","master"]
+  repository_dispatch:
+    types: [custom-event] 
+  workflow_dispatch:
+  pull_request:
+    branches: ["main","master"]
 
 permissions:
   contents: write
   pages: write
+  id-token: write
 
-  
 jobs:
   call_env_workflow:
     uses: computorg/workflows/.github/workflows/global-env.yml@main
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-    with:
-      config-path: './config/quarto_config.yml'
   call_quartopublish_workflow:
     uses: computorg/workflows/.github/workflows/publish-render.yml@main
     needs: call_env_workflow
-    with:
-      config-path: './config/quarto_config.yml'
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}

--- a/setup-render-ci.sh
+++ b/setup-render-ci.sh
@@ -1,2 +1,5 @@
-. setup-env-ci.sh
 sudo apt-get install -y inkscape
+mkdir -p ~/.local/bin
+~/.TinyTeX/bin/x86_64-linux/tlmgr option sys_bin ~/.local/bin
+~/.TinyTeX/bin/x86_64-linux/tlmgr path add
+~/.TinyTeX/bin/x86_64-linux/tlmgr update --self


### PR DESCRIPTION
Update the CI workflow to include TinyTeX path setup for diagram generation and update the main workflow for CI (no gh-pages required anymore).

You’ll have to set the source for "build and deploy" in your github settings as "github actions" and not "deploy from a branch" anymore. After that you can safely delete the branch "gh-pages".

<img width="1158" alt="image" src="https://github.com/user-attachments/assets/6f7f846d-09be-474b-8315-5ea6ed3e63e4" />
